### PR TITLE
Removed fmt print from internal.go

### DIFF
--- a/internal/api/external/internal.go
+++ b/internal/api/external/internal.go
@@ -333,7 +333,6 @@ func (a *InternalAPI) OpenIDConnectLogin(ctx context.Context, req *pb.OpenIDConn
 	user.Email = oidcUser.Email
 	user.EmailVerified = oidcUser.EmailVerified
 	if err := storage.UpdateUser(ctx, storage.DB(), &user); err != nil {
-		fmt.Println("SDFSDFSDFSDF")
 		return nil, helpers.ErrToRPCError(err)
 	}
 


### PR DESCRIPTION
Remove fmt.Println("") console print from internal.go file